### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 A traffic stop callout is generated once the player is engaged in a traffic stop and they have **exited** their vehicle.
 
 # Installation
-Download the release which contains **both** the callout and the plugin dll files. The callout must be placed in the fivepd/callouts folder and the plugin must be placed in the fivepd/callouts folder.
+Download the release which contains **both** the callout and the plugin dll files. The callout must be placed in the fivepd/callouts folder and the plugin must be placed in the fivepd/plugins folder.


### PR DESCRIPTION
readme said `TrafficStopPlugin.net.dll` must be placed in `fivepd/callouts`, however it has to go in `fivepd/plugins` folder